### PR TITLE
query dsl 동적쿼리 리팩토링

### DIFF
--- a/src/main/java/com/example/cns/feed/post/domain/repository/PostListRepository.java
+++ b/src/main/java/com/example/cns/feed/post/domain/repository/PostListRepository.java
@@ -2,11 +2,14 @@ package com.example.cns.feed.post.domain.repository;
 
 import com.example.cns.feed.post.dto.response.PostResponse;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
@@ -26,6 +29,71 @@ public class PostListRepository {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
+    //=============================================================================================================
+    // filter에 따른 동적쿼리
+    public List<PostResponse> findPosts(Long currentMemberId, Long memberId, Long cursorValue, Long pageSize, String type, LocalDate start, LocalDate end) {
+        // todo filter enum으로 변환
+        return jpaQueryFactory.select(Projections.constructor(PostResponse.class,
+                        post.id,
+                        post.member.id.as("memberId"),
+                        post.member.nickname,
+                        post.member.url.as("profile"),
+                        post.content,
+                        post.createdAt,
+                        post.likeCnt,
+                        post.fileCnt,
+                        post.comments.size().as("commentCnt"),
+                        post.isCommentEnabled,
+                        ExpressionUtils.as(JPAExpressions.select(postLike)
+                                .from(postLike)
+                                .where(postLike.post.eq(post),
+                                        postLike.member.id.eq(currentMemberId)
+                                ).exists(), "liked")
+                ))
+                .from(post)
+                .leftJoin(postLike)
+                .on(postLike.post.eq(post).and(postLike.member.id.eq(memberId)))
+                .where(decideCursor(type, cursorValue),
+                        betweenDate(start, end),
+                        eqMemberId(memberId)
+                )
+                .groupBy(post.id)
+                .orderBy(decideOrder(type))
+                .limit(pageSize)
+                .fetch();
+    }
+
+    // filter에 따라 정렬 방식 결정
+    private OrderSpecifier[] decideOrder(String type) {
+        return switch (type) {
+            case "oldest", "period" -> new OrderSpecifier[]{post.createdAt.asc()};
+            case "like" -> new OrderSpecifier[]{post.likeCnt.desc(), post.createdAt.desc()};
+            default -> new OrderSpecifier[]{post.id.desc()};
+        };
+    }
+
+    // 특정 사용자 게시물 조회를 위한 동적 쿼리 생성
+    private BooleanExpression eqMemberId(Long memberId) {
+        if (memberId == null)
+            return null;
+        return post.member.id.eq(memberId);
+    }
+
+    private BooleanExpression betweenDate(LocalDate start, LocalDate end) {
+        if (start == null || end == null)
+            return null;
+        return post.createdAt.between(start.atStartOfDay(), end.atStartOfDay());
+    }
+
+    // filter에 따라 cursorValue lt,gt 결정
+    private BooleanExpression decideCursor(String type, Long cursorValue) {
+        if (cursorValue == null)
+            return null;
+        if (type.equals("oldest") || type.equals("period")) return post.id.gt(cursorValue);
+        return post.id.lt(cursorValue);
+    }
+
+    //=============================================================================================================
     public List<PostResponse> findPostsByCondition(Long currentMemberId, Long memberId, Long cursorValue, Long pageSize, String type, LocalDate start, LocalDate end, Long likeCnt) {
 
         cursorValue = isCursorExists(cursorValue, type);
@@ -88,11 +156,11 @@ public class PostListRepository {
                         post.comments.size().as("commentCnt"),
                         post.isCommentEnabled,
                         currentMemberId.equals(memberId) ?
-                        new CaseBuilder()
-                                .when(postLike.count().gt(0))
-                                .then(true)
-                                .otherwise(false)
-                                .as("liked") :
+                                new CaseBuilder()
+                                        .when(postLike.count().gt(0))
+                                        .then(true)
+                                        .otherwise(false)
+                                        .as("liked") :
                                 Expressions.constant(false)
                 ))
                 .from(post)

--- a/src/main/java/com/example/cns/member/presentation/MemberController.java
+++ b/src/main/java/com/example/cns/member/presentation/MemberController.java
@@ -246,7 +246,7 @@ public class MemberController {
     @Operation(summary = "회원이 좋아요 누른 글 조회 api", description = "해당 회원이 좋아요 누른 글을 조회한다.")
     @Parameters(
             value = {
-                    @Parameter(name = "currentMemberId",description = "요청하는 현재 사용자 id/JWT"),
+                    @Parameter(name = "currentMemberId", description = "요청하는 현재 사용자 id/JWT"),
                     @Parameter(name = "memberId", description = "사용자 id"),
                     @Parameter(name = "cursorValue", description = "무한 스크롤 커서")
             }
@@ -257,7 +257,7 @@ public class MemberController {
     })
     @GetMapping("/{memberId}/post/liked")
     public ResponseEntity getMemberLikedPost(@Auth Long currentMemberId, @PathVariable Long memberId, @RequestParam(name = "cursorValue", required = false) Long cursorValue) {
-        List<PostResponse> likedPost = memberService.getMemberLikedPost(currentMemberId,memberId, cursorValue);
+        List<PostResponse> likedPost = memberService.getMemberLikedPost(currentMemberId, memberId, cursorValue);
         return ResponseEntity.ok(likedPost);
     }
 
@@ -287,9 +287,9 @@ public class MemberController {
                                                   @RequestParam(name = "filter", required = false) String filterType,
                                                   @RequestParam(name = "start", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
                                                   @RequestParam(name = "end", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
-                                                  @RequestParam(name = "cursorValue", required = false) Long cursorValue,
-                                                  @RequestParam(name = "likeCnt", required = false) Long likeCnt) {
-        List<PostResponse> responses = memberService.getMemberPostWithFilter(currentMemberId,memberId, filterType, start, end, cursorValue, likeCnt);
+                                                  @RequestParam(name = "cursorValue", required = false) Long cursorValue)
+    /*, @RequestParam(name = "likeCnt", required = false) Long likeCnt) */ {
+        List<PostResponse> responses = memberService.getMemberPostWithFilter(currentMemberId, memberId, filterType, start, end, cursorValue/*, likeCnt*/);
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/example/cns/member/service/MemberService.java
+++ b/src/main/java/com/example/cns/member/service/MemberService.java
@@ -188,8 +188,9 @@ public class MemberService {
         return postResponseWithData(posts);
     }
 
-    public List<PostResponse> getMemberPostWithFilter(Long currentMemberId, Long memberId, String filterType, LocalDate start, LocalDate end, Long cursorValue, Long likeCnt) {
-        List<PostResponse> posts = postListRepository.findPostsByCondition(currentMemberId, memberId, cursorValue, 10L, filterType, start, end, likeCnt);
+    public List<PostResponse> getMemberPostWithFilter(Long currentMemberId, Long memberId, String filterType, LocalDate start, LocalDate end, Long cursorValue/*, Long likeCnt*/) {
+        //List<PostResponse> posts = postListRepository.findPostsByCondition(currentMemberId, memberId, cursorValue, 10L, filterType, start, end, likeCnt);
+        List<PostResponse> posts = postListRepository.findPosts(currentMemberId, memberId, cursorValue, 10L, filterType, start, end);
         return postResponseWithData(posts);
     }
 


### PR DESCRIPTION
## 필터링에 따라 동적 쿼리 생성   
switch문 대신 함수를 통해 동적쿼리를 생성하도록 리팩토링해보았습니다.
또한 좋아요순으로 정렬 시 likeCnt 파라미터는 필요없을 거 같아 삭제하였습니다💪💪
   
## 좋아요 여부 서브쿼리
기존 : 로그인 사용자와 검색할 프로필을 비교 후 좋아요 개수 gt 0
수정 :  로그인한 사용자 id로 where문을 통한 검색

확인해주세욧🤗🤗