### PR TITLE
[hotfix] 회원 프로필 이미지 수정, 이력서 수정시 오류 발생

### DIFF
--- a/src/main/java/com/example/cns/member/domain/Member.java
+++ b/src/main/java/com/example/cns/member/domain/Member.java
@@ -57,11 +57,11 @@ public class Member extends FileEntity {
     @Enumerated(EnumType.STRING)
     private RoleType role;
 
-    @Column(name = "is_profile_existed")
+    @Column(name = "is_profile_existed",columnDefinition = "TINYINT(0)")
     @ColumnDefault("false")
     private Boolean isProfileExisted;
 
-    @Column(name = "is_resume_existed")
+    @Column(name = "is_resume_existed", columnDefinition = "TINYINT(0)")
     @ColumnDefault("false")
     private Boolean isResumeExisted;
 
@@ -82,6 +82,16 @@ public class Member extends FileEntity {
         this.birth = birth;
         this.role = role;
         this.position = position;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (this.isProfileExisted == null) {
+            this.isProfileExisted = false;
+        }
+        if (this.isResumeExisted == null) {
+            this.isResumeExisted = false;
+        }
     }
 
     public void enrollCompany(Company company) {

--- a/src/main/java/com/example/cns/member/service/MemberService.java
+++ b/src/main/java/com/example/cns/member/service/MemberService.java
@@ -159,8 +159,7 @@ public class MemberService {
             } catch (IOException e) {
                 throw new BusinessException(ExceptionCode.IMAGE_DELETE_FAILED);
             }
-        }
-        throw new BusinessException(ExceptionCode.RESUME_NOT_EXIST);
+        }else throw new BusinessException(ExceptionCode.RESUME_NOT_EXIST);
 
     }
 


### PR DESCRIPTION
### 회원 프로필 이미지 수정, 이력서 수정시 오류 발생

**원인**
회원 생성시에 이미지, 이력서 여부가 null값으로 설정되어서 발생하였습니다.

**해결**
회원 생성시에 기본값으로 false값 설정하여 문제 해결했습니다.