### PR TITLE
refactor : S3 URL 노출 변경

### DIFF
--- a/src/main/java/com/example/cns/common/service/S3Service.java
+++ b/src/main/java/com/example/cns/common/service/S3Service.java
@@ -31,6 +31,9 @@ public class S3Service {
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;
 
+    @Value("${spring.cloud.aws.cloudfront.url}")
+    private String cloudFront;
+
     private static FileType getFileType(String ext) {
         return switch (ext) {
             case "png", "PNG" -> FileType.PNG;
@@ -81,7 +84,7 @@ public class S3Service {
                             .withCannedAcl(CannedAccessControlList.PublicRead)
             );
 
-            uploadFileURL = amazonS3Client.getUrl(bucketName, keyName).toString();
+            uploadFileURL = cloudFront+keyName;
             return new FileResponse(uploadFileName, uploadFileURL, fileType);
         } catch (IOException e) {
             throw new BusinessException(ExceptionCode.IMAGE_UPLOAD_FAILED);

--- a/src/main/java/com/example/cns/feed/post/service/PostService.java
+++ b/src/main/java/com/example/cns/feed/post/service/PostService.java
@@ -352,6 +352,7 @@ public class PostService {
         Post post = isPostExists(postLikeRequest.postId());
         if (postLikeRepository.existsByPostAndMember(post, member)) {
             postLikeRepository.deleteByPostAndMember(post, member);
+            post.minusLikeCnt();
         }
 
       /*  if (postLike.isPresent()) {


### PR DESCRIPTION
### S3 URL 노출 변경
문제점
- 기존에 S3 URL 기본을 그냥 이용하면서 어떤 서버에서 사용되고 있는지 나타나고 있었습니다.

해결
- CloudFront를 통해 S3 URL을 감추었습니다.
- 비용 문제로 보안 설정은 추가로 하지 않고 기본 설정으로 진행합니다.
- 추가적으로 DB에 있는 모든 객체들 URL 수정 완료 했습니다.